### PR TITLE
Fix scopes

### DIFF
--- a/src/mirage.nix
+++ b/src/mirage.nix
@@ -101,7 +101,7 @@ in rec {
           (mapTargets (mkScopeOpam unikernelName mirageDir depexts monorepoQuery));
         targetScopes = mapAttrs'
           (target: scope: nameValuePair "${target}-scope" scope)
-          (mapTargets (mkScopeOpam unikernelName mirageDir depexts));
+          (mapTargets (mkScopeOpam unikernelName mirageDir depexts monorepoQuery));
         targetMonorepoScopes = mapAttrs'
           (target: scope: nameValuePair "${target}-monorepo" scope)
           (mapTargets (mkScopeMonorepo monorepoQuery));


### PR DESCRIPTION
When introducing the `monorepoQuery` parameter in https://github.com/RyanGibb/hillingar/commit/4a36a317e07998482c431ecb86f045e3efd43c96 the `mkScopeOpam` invocation used to build the scopes did not get updated to include the new argument, making  `*-scope` attributes (unusable) lambdas. This PR fixes this. I assume that just got missed :)

And thanks for the project!