### PR TITLE
Replace overrideScope' with overrideScope

### DIFF
--- a/src/mirage.nix
+++ b/src/mirage.nix
@@ -91,7 +91,7 @@ in rec {
       };
     in rec {
       scope =
-        (buildOpamProject queryArgs pkg_name src query).overrideScope' overlay;
+        (buildOpamProject queryArgs pkg_name src query).overrideScope overlay;
       unikernel = scope.${pkg_name};
     };
 


### PR DESCRIPTION
overrideScope' is a deprecated alias[1] of overrideScope. overrideScope' has been removed[2] and using it in newer Nixpkgs causes eval error.

[1]: https://github.com/NixOS/nixpkgs/blob/bb54a0c1977614ea64113f587396ecc55d0f0f4a/lib/customisation.nix#L547C11-L547C25
[2]: https://github.com/NixOS/nixpkgs/commit/af10dd201409ca9ba396507544f35d9dbaea2e98